### PR TITLE
Implement basic farming game logic with simple UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,3 +208,7 @@ This repository contains a minimal pixel-retro prototype implemented in plain HT
 
 - Open `index.html` in a browser to play.
 - Run `node tests/test_game.js` to execute a small logic test of the core loop.
+
+## Farm Game
+
+A simple farming prototype is available as well. Open `farm.html` in a browser to plant seeds, grow crops, and sell your harvest. Core logic lives in `farmGame.js` and is tested with `tests/test_farmGame.js`.

--- a/farm.html
+++ b/farm.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Farm Game</title>
+  <link rel="stylesheet" href="farmStyles.css" />
+</head>
+<body>
+  <div id="hud">Money: $<span id="money"></span> <button id="next-day">Next Day</button></div>
+  <div id="tools">
+    <button data-tool="hoe">Hoe</button>
+    <button data-tool="water">Water</button>
+    <button data-tool="fertilize">Fertilize</button>
+    <button data-tool="harvest">Harvest</button>
+    <select id="seed-select"></select>
+    <button data-tool="plant" id="plant-btn">Plant</button>
+    <button id="buy-seed">Buy Seed</button>
+  </div>
+  <div id="grid"></div>
+  <div id="inventory"></div>
+  <script src="farmGame.js"></script>
+  <script src="farmUI.js"></script>
+</body>
+</html>

--- a/farmGame.js
+++ b/farmGame.js
@@ -1,0 +1,118 @@
+class FarmGame {
+  constructor(options = {}) {
+    this.width = 20;
+    this.height = 20;
+    this.money = options.startingMoney ?? 100;
+    this.inventory = {
+      seeds: {},
+      crops: {}
+    };
+    this.seedTypes = {
+      carrot: { cost: 5, sellPrice: 10, growth: 3 },
+      potato: { cost: 8, sellPrice: 15, growth: 4 }
+    };
+    this.grid = [];
+    for (let y = 0; y < this.height; y++) {
+      const row = [];
+      for (let x = 0; x < this.width; x++) {
+        row.push(this._createTile());
+      }
+      this.grid.push(row);
+    }
+  }
+
+  _createTile() {
+    return {
+      tilled: false,
+      watered: false,
+      fertilized: false,
+      crop: null
+    };
+  }
+
+  _getTile(x, y) {
+    if (x < 0 || x >= this.width || y < 0 || y >= this.height) return null;
+    return this.grid[y][x];
+  }
+
+  buySeed(type, qty = 1) {
+    const seed = this.seedTypes[type];
+    if (!seed) return false;
+    const cost = seed.cost * qty;
+    if (this.money < cost) return false;
+    this.money -= cost;
+    this.inventory.seeds[type] = (this.inventory.seeds[type] || 0) + qty;
+    return true;
+  }
+
+  sellCrop(type, qty = 1) {
+    const cropQty = this.inventory.crops[type] || 0;
+    if (qty > cropQty) return false;
+    const seed = this.seedTypes[type];
+    const revenue = seed.sellPrice * qty;
+    this.inventory.crops[type] -= qty;
+    this.money += revenue;
+    return true;
+  }
+
+  till(x, y) {
+    const tile = this._getTile(x, y);
+    if (!tile) return false;
+    tile.tilled = true;
+    return true;
+  }
+
+  water(x, y) {
+    const tile = this._getTile(x, y);
+    if (!tile) return false;
+    tile.watered = true;
+    return true;
+  }
+
+  fertilize(x, y) {
+    const tile = this._getTile(x, y);
+    if (!tile) return false;
+    tile.fertilized = true;
+    return true;
+  }
+
+  plant(x, y, type) {
+    const tile = this._getTile(x, y);
+    if (!tile || !tile.tilled || tile.crop) return false;
+    const seedQty = this.inventory.seeds[type] || 0;
+    if (seedQty < 1) return false;
+    this.inventory.seeds[type] -= 1;
+    const seed = this.seedTypes[type];
+    tile.crop = { type, stage: 0, growth: seed.growth };
+    tile.watered = false;
+    return true;
+  }
+
+  harvest(x, y) {
+    const tile = this._getTile(x, y);
+    if (!tile || !tile.crop) return false;
+    if (tile.crop.stage < tile.crop.growth) return false;
+    const type = tile.crop.type;
+    this.inventory.crops[type] = (this.inventory.crops[type] || 0) + 1;
+    this.grid[y][x] = this._createTile();
+    return true;
+  }
+
+  nextDay() {
+    for (let y = 0; y < this.height; y++) {
+      for (let x = 0; x < this.width; x++) {
+        const tile = this.grid[y][x];
+        if (tile.crop) {
+          if (tile.watered) {
+            tile.crop.stage += tile.fertilized ? 2 : 1;
+          }
+          tile.watered = false;
+        }
+      }
+    }
+  }
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { FarmGame };
+}

--- a/farmStyles.css
+++ b/farmStyles.css
@@ -1,0 +1,28 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 10px;
+}
+#grid {
+  display: grid;
+  grid-template-columns: repeat(20, 20px);
+  grid-template-rows: repeat(20, 20px);
+  gap: 2px;
+  margin-top: 10px;
+}
+.tile {
+  width: 20px;
+  height: 20px;
+  background: #654321;
+}
+.tile.tilled { background: #8B4513; }
+.tile.crop { background: #228B22; }
+.tile.ready { background: goldenrod; }
+.tile.watered { outline: 2px solid #00f; }
+.tile.fertilized { outline: 2px solid #ff0; }
+#tools button {
+  margin-right: 5px;
+}
+#inventory {
+  margin-top: 10px;
+}

--- a/farmUI.js
+++ b/farmUI.js
@@ -1,0 +1,109 @@
+const game = new FarmGame();
+let currentTool = 'hoe';
+
+const moneySpan = document.getElementById('money');
+const gridDiv = document.getElementById('grid');
+const seedSelect = document.getElementById('seed-select');
+
+function init() {
+  Object.keys(game.seedTypes).forEach(type => {
+    const opt = document.createElement('option');
+    opt.value = type;
+    opt.textContent = `${type} ($${game.seedTypes[type].cost})`;
+    seedSelect.appendChild(opt);
+  });
+  document.querySelectorAll('#tools button[data-tool]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      currentTool = btn.dataset.tool;
+    });
+  });
+  document.getElementById('buy-seed').addEventListener('click', () => {
+    const type = seedSelect.value;
+    game.buySeed(type);
+    render();
+  });
+  document.getElementById('next-day').addEventListener('click', () => {
+    game.nextDay();
+    render();
+  });
+  render();
+}
+
+function render() {
+  moneySpan.textContent = game.money;
+  renderGrid();
+  renderInventory();
+}
+
+function renderGrid() {
+  gridDiv.innerHTML = '';
+  for (let y = 0; y < game.height; y++) {
+    for (let x = 0; x < game.width; x++) {
+      const tileDiv = document.createElement('div');
+      tileDiv.classList.add('tile');
+      const tile = game.grid[y][x];
+      if (tile.tilled) tileDiv.classList.add('tilled');
+      if (tile.crop) {
+        tileDiv.classList.add('crop');
+        if (tile.crop.stage >= tile.crop.growth) tileDiv.classList.add('ready');
+      }
+      if (tile.watered) tileDiv.classList.add('watered');
+      if (tile.fertilized) tileDiv.classList.add('fertilized');
+      tileDiv.addEventListener('click', () => handleTile(x, y));
+      gridDiv.appendChild(tileDiv);
+    }
+  }
+}
+
+function handleTile(x, y) {
+  switch (currentTool) {
+    case 'hoe':
+      game.till(x, y);
+      break;
+    case 'water':
+      game.water(x, y);
+      break;
+    case 'fertilize':
+      game.fertilize(x, y);
+      break;
+    case 'harvest':
+      game.harvest(x, y);
+      break;
+    case 'plant':
+      game.plant(x, y, seedSelect.value);
+      break;
+  }
+  render();
+}
+
+function renderInventory() {
+  const inv = document.getElementById('inventory');
+  inv.innerHTML = '';
+  const seedHeader = document.createElement('div');
+  seedHeader.textContent = 'Seeds';
+  inv.appendChild(seedHeader);
+  Object.entries(game.inventory.seeds).forEach(([type, qty]) => {
+    const row = document.createElement('div');
+    row.textContent = `${type}: ${qty}`;
+    inv.appendChild(row);
+  });
+  const cropHeader = document.createElement('div');
+  cropHeader.textContent = 'Crops';
+  inv.appendChild(cropHeader);
+  Object.entries(game.inventory.crops).forEach(([type, qty]) => {
+    const row = document.createElement('div');
+    const span = document.createElement('span');
+    span.textContent = `${type}: ${qty}`;
+    row.appendChild(span);
+    const btn = document.createElement('button');
+    btn.textContent = `Sell ($${game.seedTypes[type].sellPrice})`;
+    btn.addEventListener('click', () => {
+      game.sellCrop(type, 1);
+      render();
+    });
+    row.appendChild(btn);
+    inv.appendChild(row);
+  });
+}
+
+init();

--- a/tests/test_farmGame.js
+++ b/tests/test_farmGame.js
@@ -1,0 +1,42 @@
+const assert = require('assert');
+const { FarmGame } = require('../farmGame.js');
+
+const game = new FarmGame({ startingMoney: 100 });
+
+// grid size
+assert.strictEqual(game.grid.length, 20);
+assert.strictEqual(game.grid[0].length, 20);
+
+// buy seeds
+const bought = game.buySeed('carrot', 2);
+assert.ok(bought);
+assert.strictEqual(game.money, 100 - 10);
+assert.strictEqual(game.inventory.seeds.carrot, 2);
+
+// plant and grow without fertilizer
+assert.ok(game.till(0, 0));
+assert.ok(game.plant(0, 0, 'carrot'));
+for (let day = 0; day < 3; day++) {
+  game.water(0, 0);
+  game.nextDay();
+}
+assert.ok(game.harvest(0, 0));
+assert.strictEqual(game.inventory.crops.carrot, 1);
+
+// fertilizer speeds growth
+assert.ok(game.till(1, 0));
+assert.ok(game.fertilize(1, 0));
+assert.ok(game.plant(1, 0, 'carrot'));
+for (let day = 0; day < 2; day++) {
+  game.water(1, 0);
+  game.nextDay();
+}
+assert.ok(game.harvest(1, 0));
+assert.strictEqual(game.inventory.crops.carrot, 2);
+
+// selling crops
+const sold = game.sellCrop('carrot', 2);
+assert.ok(sold);
+assert.strictEqual(game.money, 100 - 10 + 20);
+
+console.log('FarmGame tests passed');


### PR DESCRIPTION
## Summary
- add FarmGame class with 20x20 grid, economic system, and crop growth mechanics
- create tests covering seed purchase, planting, fertilizer growth boost, harvesting, and selling
- provide browser UI with tool menu, grid display, and inventory for the FarmGame

## Testing
- `node tests/test_game.js`
- `node tests/test_farmGame.js`


------
https://chatgpt.com/codex/tasks/task_e_68a1afd6b5fc83218571463127bd60d2